### PR TITLE
Add live subtitles SwiftUI project

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LiveSubtitlesApp",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .executable(name: "LiveSubtitlesApp", targets: ["LiveSubtitlesApp"])
+    ],
+    dependencies: [
+        // No external dependencies
+    ],
+    targets: [
+        .executableTarget(
+            name: "LiveSubtitlesApp",
+            path: "Sources"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
 # subtitles
+
+## Live Subtitles App
+
+This repository now includes a minimal SwiftUI project demonstrating live subtitle capture on iOS.
+
+### Features
+* Select the subtitle language
+* Start/stop listening with a single button
+* Request microphone permissions with an explanation
+* Display recognized speech live on screen (ready for translation)
+
+### Choosing a Speech Recognition Model
+For iOS, consider these options:
+1. **Apple Speech framework**: Built-in and easy to integrate; performs speech recognition on device when supported or via Apple's servers.
+2. **OpenAI Whisper**: High accuracy open-source model. A "faster-whisper" variant can run on-device with Metal or CPU acceleration. Requires bundling the model and bridging C/C++ code to Swift.
+3. **Other SDKs**: Services like Google Cloud Speech-to-Text or Azure Speech also provide iOS SDKs, but require network connectivity.
+
+If you prefer on-device processing with good speed, using Apple's built-in framework is simplest. Whisper provides strong accuracy but needs integration work.
+
+### Building the project
+The Swift package can be opened directly in Xcode 15 or later:
+
+```bash
+xed .
+```
+
+Once opened, build and run the `LiveSubtitlesApp` target on an iOS device or simulator.
+
+The project requests microphone access via the `NSMicrophoneUsageDescription` key in `Info.plist`:
+
+```
+<key>NSMicrophoneUsageDescription</key>
+<string>This app uses the microphone to capture audio for live subtitles.</string>
+```
+
+The live transcription is handled by `SubtitleManager` using `SFSpeechRecognizer`. Translation logic can be added in the same class if desired.
+

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>LiveSubtitlesApp</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.LiveSubtitlesApp</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.utilities</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>This app uses the microphone to capture audio for live subtitles.</string>
+</dict>
+</plist>

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var manager = SubtitleManager()
+    @State private var showLanguages = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Button(manager.selectedLanguageName) {
+                showLanguages = true
+            }
+            .sheet(isPresented: $showLanguages) {
+                LanguageSelectionView(selected: $manager.selectedLocaleIdentifier)
+            }
+
+            ScrollView {
+                Text(manager.translatedText)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding()
+            }
+            .frame(maxHeight: 200)
+
+            Button(action: {
+                if manager.isListening {
+                    manager.stop()
+                } else {
+                    manager.start()
+                }
+            }) {
+                Text(manager.isListening ? "Stop" : "Start")
+                    .font(.title)
+                    .frame(maxWidth: .infinity)
+            }
+            .padding()
+            .background(Color.accentColor)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+            .disabled(!manager.permissionGranted)
+        }
+        .padding()
+        .onAppear {
+            manager.requestPermission()
+        }
+    }
+}
+
+struct LanguageSelectionView: View {
+    @Binding var selected: String
+
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach(SubtitleManager.supportedLocales, id: \.identifier) { locale in
+                    Button(action: {
+                        selected = locale.identifier
+                    }) {
+                        HStack {
+                            Text(locale.localizedString(forLanguageCode: locale.languageCode ?? locale.identifier) ?? locale.identifier)
+                            if selected == locale.identifier {
+                                Spacer()
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Language")
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Sources/LiveSubtitlesApp.swift
+++ b/Sources/LiveSubtitlesApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct LiveSubtitlesApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Sources/SubtitleManager.swift
+++ b/Sources/SubtitleManager.swift
@@ -1,0 +1,72 @@
+import Foundation
+import AVFoundation
+import Speech
+
+class SubtitleManager: NSObject, ObservableObject, SFSpeechRecognizerDelegate {
+    @Published var translatedText: String = ""
+    @Published var selectedLocaleIdentifier: String = Locale.current.identifier
+    @Published var isListening: Bool = false
+    @Published var permissionGranted: Bool = false
+
+    private var recognizer: SFSpeechRecognizer?
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    static var supportedLocales: [Locale] {
+        SFSpeechRecognizer.supportedLocales().map { Locale(identifier: $0.identifier) }.sorted { $0.identifier < $1.identifier }
+    }
+
+    var selectedLanguageName: String {
+        Locale.current.localizedString(forIdentifier: selectedLocaleIdentifier) ?? selectedLocaleIdentifier
+    }
+
+    func requestPermission() {
+        SFSpeechRecognizer.requestAuthorization { status in
+            DispatchQueue.main.async {
+                self.permissionGranted = status == .authorized
+            }
+        }
+        AVAudioSession.sharedInstance().requestRecordPermission { granted in
+            DispatchQueue.main.async {
+                self.permissionGranted = self.permissionGranted && granted
+            }
+        }
+    }
+
+    func start() {
+        guard permissionGranted else { return }
+        translatedText = ""
+        isListening = true
+        recognizer = SFSpeechRecognizer(locale: Locale(identifier: selectedLocaleIdentifier))
+        request = SFSpeechAudioBufferRecognitionRequest()
+        let node = audioEngine.inputNode
+        let format = node.outputFormat(forBus: 0)
+        node.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            self.request?.append(buffer)
+        }
+        audioEngine.prepare()
+        try? audioEngine.start()
+        task = recognizer?.recognitionTask(with: request!) { result, error in
+            if let text = result?.bestTranscription.formattedString {
+                DispatchQueue.main.async {
+                    // Placeholder for translation step
+                    self.translatedText = text
+                }
+            }
+            if error != nil || (result?.isFinal ?? false) {
+                self.stop()
+            }
+        }
+    }
+
+    func stop() {
+        isListening = false
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        request?.endAudio()
+        task?.cancel()
+        request = nil
+        task = nil
+    }
+}


### PR DESCRIPTION
## Summary
- create Swift package for iOS live subtitles demo
- add SwiftUI screens for language selection and start/stop listening
- implement SubtitleManager using Speech framework
- include Info.plist with microphone permission text
- update README with build instructions

## Testing
- `swift build` *(fails: no SwiftUI module available on linux)*

------
https://chatgpt.com/codex/tasks/task_b_688bcd038f4c8330ba0c7ce399562360