### PR TITLE
Add live subtitle translation example

### DIFF
--- a/LiveSubtitles/LiveSubtitles.xcodeproj/project.pbxproj
+++ b/LiveSubtitles/LiveSubtitles.xcodeproj/project.pbxproj
@@ -414,6 +414,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bibasx.livesubtitles.LiveSubtitles;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Microphone access is required to transcribe speech for live subtitles.";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
@@ -453,6 +454,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bibasx.livesubtitles.LiveSubtitles;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Microphone access is required to transcribe speech for live subtitles.";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";

--- a/LiveSubtitles/LiveSubtitles/ContentView.swift
+++ b/LiveSubtitles/LiveSubtitles/ContentView.swift
@@ -1,19 +1,68 @@
-//
-//  ContentView.swift
-//  LiveSubtitles
-//
-//  Created by Christos Bimpas on 01/08/2025.
-//
-
 import SwiftUI
+import AVFoundation
+import Speech
+
+@MainActor
+final class SubtitlesViewModel: ObservableObject {
+    @Published var selectedLanguage: Language? = nil
+    @Published var isRecording = false
+    @Published var translatedText = ""
+    @Published var showSelector = false
+
+    private let recognizer = SpeechRecognizer()
+    private let translator = Translator()
+
+    func toggleRecording() {
+        if isRecording {
+            recognizer.stop()
+            isRecording = false
+        } else {
+            translatedText = ""
+            Task {
+                let audioGranted = await withCheckedContinuation { cont in
+                    AVAudioSession.sharedInstance().requestRecordPermission { allowed in
+                        cont.resume(returning: allowed)
+                    }
+                }
+                guard audioGranted else { return }
+            }
+            SFSpeechRecognizer.requestAuthorization { _ in }
+            isRecording = true
+            try? recognizer.start { [weak self] text in
+                guard let self = self else { return }
+                Task {
+                    let target = self.selectedLanguage?.code ?? "en"
+                    let translated = await self.translator.translate(text, to: target)
+                    await MainActor.run {
+                        self.translatedText = translated
+                    }
+                }
+            }
+        }
+    }
+}
 
 struct ContentView: View {
+    @StateObject private var model = SubtitlesViewModel()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(spacing: 20) {
+            HStack {
+                Button(model.selectedLanguage?.name ?? "Select Language") {
+                    model.showSelector = true
+                }
+                Button(model.isRecording ? "Stop" : "Listen") {
+                    model.toggleRecording()
+                }
+            }
+            ScrollView {
+                Text(model.translatedText)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+        }
+        .sheet(isPresented: $model.showSelector) {
+            LanguageSelectionView(languages: Language.supported, selected: $model.selectedLanguage)
         }
         .padding()
     }

--- a/LiveSubtitles/LiveSubtitles/Language.swift
+++ b/LiveSubtitles/LiveSubtitles/Language.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct Language: Identifiable, Hashable {
+    let id = UUID()
+    let code: String
+    let name: String
+}
+
+extension Language {
+    static let supported: [Language] = [
+        Language(code: "en", name: "English"),
+        Language(code: "es", name: "Spanish"),
+        Language(code: "fr", name: "French"),
+        Language(code: "de", name: "German"),
+        Language(code: "it", name: "Italian"),
+        Language(code: "pt", name: "Portuguese"),
+        Language(code: "ru", name: "Russian"),
+        Language(code: "zh", name: "Chinese")
+    ]
+}

--- a/LiveSubtitles/LiveSubtitles/LanguageSelectionView.swift
+++ b/LiveSubtitles/LiveSubtitles/LanguageSelectionView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct LanguageSelectionView: View {
+    let languages: [Language]
+    @Binding var selected: Language?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List(languages, id: \.self) { language in
+                Button(language.name) {
+                    selected = language
+                    dismiss()
+                }
+            }
+            .navigationTitle("Choose Language")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+}

--- a/LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift
+++ b/LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Speech
+import AVFoundation
+
+class SpeechRecognizer {
+    private var audioEngine: AVAudioEngine?
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    func start(locale: Locale = Locale(identifier: "en-US"), onResult: @escaping (String) -> Void) throws {
+        stop()
+        let recognizer = SFSpeechRecognizer(locale: locale)
+        guard let recognizer = recognizer, recognizer.isAvailable else { return }
+
+        audioEngine = AVAudioEngine()
+        request = SFSpeechAudioBufferRecognitionRequest()
+        guard let request = request, let audioEngine = audioEngine else { return }
+        request.shouldReportPartialResults = true
+
+        task = recognizer.recognitionTask(with: request) { result, error in
+            if let result = result {
+                onResult(result.bestTranscription.formattedString)
+            }
+        }
+
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            request.append(buffer)
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+    }
+
+    func stop() {
+        audioEngine?.stop()
+        request?.endAudio()
+        task?.cancel()
+        audioEngine = nil
+        request = nil
+        task = nil
+    }
+}

--- a/LiveSubtitles/LiveSubtitles/Translator.swift
+++ b/LiveSubtitles/LiveSubtitles/Translator.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+class Translator {
+    func translate(_ text: String, to target: String) async -> String {
+        guard let url = URL(string: "https://libretranslate.de/translate") else { return text }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        let query = "q=" + (text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "") + "&source=auto&target=\(target)&format=text"
+        request.httpBody = query.data(using: .utf8)
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let translated = json["translatedText"] as? String {
+                return translated
+            }
+        } catch {
+            print("Translation error", error)
+        }
+        return text
+    }
+}


### PR DESCRIPTION
## Summary
- implement a basic UI to select language and start/stop subtitle capture
- add speech recognizer and translator helpers
- include language selector view
- require microphone access in project settings

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_b_688c860ec118833080fb04ba11e30030