### PR TITLE
Add speech recognition usage description

### DIFF
--- a/LiveSubtitles/LiveSubtitles.xcodeproj/project.pbxproj
+++ b/LiveSubtitles/LiveSubtitles.xcodeproj/project.pbxproj
@@ -414,7 +414,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bibasx.livesubtitles.LiveSubtitles;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Microphone access is required to transcribe speech for live subtitles.";
+                                INFOPLIST_KEY_NSMicrophoneUsageDescription = "Microphone access is required to transcribe speech for live subtitles.";
+                                INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Speech recognition is required to transcribe audio for live subtitles.";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
@@ -453,9 +454,10 @@
 				MACOSX_DEPLOYMENT_TARGET = 15.5;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bibasx.livesubtitles.LiveSubtitles;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Microphone access is required to transcribe speech for live subtitles.";
-				REGISTER_APP_GROUPS = YES;
+                                PRODUCT_NAME = "$(TARGET_NAME)";
+                                INFOPLIST_KEY_NSMicrophoneUsageDescription = "Microphone access is required to transcribe speech for live subtitles.";
+                                INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Speech recognition is required to transcribe audio for live subtitles.";
+                                REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## Summary
- include `NSSpeechRecognitionUsageDescription` in generated Info.plist settings

## Testing
- `grep -n NSSpeechRecognitionUsageDescription -n LiveSubtitles/LiveSubtitles.xcodeproj/project.pbxproj`

------
https://chatgpt.com/codex/tasks/task_b_688c916a89f483309740194f3c8d8a0c