### PR TITLE
Fix audio session crash

### DIFF
--- a/LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift
+++ b/LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift
@@ -12,6 +12,10 @@ class SpeechRecognizer {
         let recognizer = SFSpeechRecognizer(locale: locale)
         guard let recognizer = recognizer, recognizer.isAvailable else { return }
 
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+
         audioEngine = AVAudioEngine()
         request = SFSpeechAudioBufferRecognitionRequest()
         guard let request = request, let audioEngine = audioEngine else { return }


### PR DESCRIPTION
## Summary
- configure `AVAudioSession` before creating `AVAudioEngine`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_688c97dac3dc8330a52afe434a398d5d