### PR TITLE
Add Greek and auto language detection

### DIFF
--- a/LiveSubtitles/LiveSubtitles/Language.swift
+++ b/LiveSubtitles/LiveSubtitles/Language.swift
@@ -15,6 +15,7 @@ extension Language {
         Language(code: "it", name: "Italian"),
         Language(code: "pt", name: "Portuguese"),
         Language(code: "ru", name: "Russian"),
-        Language(code: "zh", name: "Chinese")
+        Language(code: "zh", name: "Chinese"),
+        Language(code: "el", name: "Greek")
     ]
 }

--- a/LiveSubtitles/LiveSubtitles/Translator.swift
+++ b/LiveSubtitles/LiveSubtitles/Translator.swift
@@ -1,11 +1,19 @@
 import Foundation
+import NaturalLanguage
 
 class Translator {
+    private func detectLanguage(of text: String) -> String? {
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(text)
+        return recognizer.dominantLanguage?.rawValue
+    }
+
     func translate(_ text: String, to target: String) async -> String {
+        let source = detectLanguage(of: text) ?? "auto"
         guard let url = URL(string: "https://libretranslate.de/translate") else { return text }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        let query = "q=" + (text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "") + "&source=auto&target=\(target)&format=text"
+        let query = "q=" + (text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "") + "&source=\(source)&target=\(target)&format=text"
         request.httpBody = query.data(using: .utf8)
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         do {


### PR DESCRIPTION
## Summary
- detect source language using `NLLanguageRecognizer` before translating
- add Greek to the list of languages

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_688c99b195a88330b5ec370d4b46207f