### PR TITLE
Allow choosing input and output languages

### DIFF
--- a/LiveSubtitles/LiveSubtitles/Language.swift
+++ b/LiveSubtitles/LiveSubtitles/Language.swift
@@ -2,20 +2,38 @@ import Foundation
 
 struct Language: Identifiable, Hashable {
     let id = UUID()
+    /// Two letter translation code used by the translation API.
     let code: String
+    /// Display name for the language.
     let name: String
+    /// Optional locale identifier used for speech recognition.
+    let speechCode: String?
+
+    var locale: Locale? {
+        guard let speechCode else { return nil }
+        return Locale(identifier: speechCode)
+    }
 }
 
 extension Language {
+    /// Special value used when the input language should be detected
+    /// automatically.
+    static let automatic = Language(code: "auto", name: "Automatic", speechCode: nil)
+
+    /// Languages supported for both speech recognition and translation.
     static let supported: [Language] = [
-        Language(code: "en", name: "English"),
-        Language(code: "es", name: "Spanish"),
-        Language(code: "fr", name: "French"),
-        Language(code: "de", name: "German"),
-        Language(code: "it", name: "Italian"),
-        Language(code: "pt", name: "Portuguese"),
-        Language(code: "ru", name: "Russian"),
-        Language(code: "zh", name: "Chinese"),
-        Language(code: "el", name: "Greek")
+        Language(code: "en", name: "English", speechCode: "en-US"),
+        Language(code: "es", name: "Spanish", speechCode: "es-ES"),
+        Language(code: "fr", name: "French", speechCode: "fr-FR"),
+        Language(code: "de", name: "German", speechCode: "de-DE"),
+        Language(code: "it", name: "Italian", speechCode: "it-IT"),
+        Language(code: "pt", name: "Portuguese", speechCode: "pt-PT"),
+        Language(code: "ru", name: "Russian", speechCode: "ru-RU"),
+        Language(code: "zh", name: "Chinese", speechCode: "zh-CN"),
+        Language(code: "el", name: "Greek", speechCode: "el-GR")
     ]
+
+    /// Available choices for the input language selector. The first entry
+    /// enables automatic detection using the translator.
+    static let inputChoices: [Language] = [automatic] + supported
 }

--- a/LiveSubtitles/LiveSubtitles/LanguageSelectionView.swift
+++ b/LiveSubtitles/LiveSubtitles/LanguageSelectionView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct LanguageSelectionView: View {
     let languages: [Language]
-    @Binding var selected: Language?
+    @Binding var selected: Language
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {

--- a/LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift
+++ b/LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift
@@ -7,9 +7,11 @@ class SpeechRecognizer {
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
 
-    func start(locale: Locale = Locale(identifier: "en-US"), onResult: @escaping (String) -> Void) throws {
+    /// Starts listening using the provided locale. If no locale is supplied the
+    /// device's current locale is used.
+    func start(locale: Locale? = nil, onResult: @escaping (String) -> Void) throws {
         stop()
-        let recognizer = SFSpeechRecognizer(locale: locale)
+        let recognizer = SFSpeechRecognizer(locale: locale ?? Locale.current)
         guard let recognizer = recognizer, recognizer.isAvailable else { return }
 
         let session = AVAudioSession.sharedInstance()

--- a/LiveSubtitles/LiveSubtitles/Translator.swift
+++ b/LiveSubtitles/LiveSubtitles/Translator.swift
@@ -8,8 +8,10 @@ class Translator {
         return recognizer.dominantLanguage?.rawValue
     }
 
-    func translate(_ text: String, to target: String) async -> String {
-        let source = detectLanguage(of: text) ?? "auto"
+    /// Translates the provided text. A specific source language can be
+    /// supplied; otherwise automatic detection will be used.
+    func translate(_ text: String, from source: String?, to target: String) async -> String {
+        let source = source ?? detectLanguage(of: text) ?? "auto"
         guard let url = URL(string: "https://libretranslate.de/translate") else { return text }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"


### PR DESCRIPTION
## Summary
- add speech locale information in `Language`
- add an input language selector and update UI
- allow passing a specific input language to the recognizer and translator

## Testing
- `swiftc -typecheck LiveSubtitles/LiveSubtitles/*.swift` *(fails: no such module `SwiftUI`)*

------
https://chatgpt.com/codex/tasks/task_b_688c9c2cd7d08330ba60ca58813565b6