### PR TITLE
Fix network access for translations

### DIFF
--- a/LiveSubtitles/LiveSubtitles/LiveSubtitles.entitlements
+++ b/LiveSubtitles/LiveSubtitles/LiveSubtitles.entitlements
@@ -4,6 +4,8 @@
 <dict>
     <key>com.apple.security.app-sandbox</key>
     <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
 </dict>


### PR DESCRIPTION
## Summary
- allow network client access in macOS sandbox so translations can be fetched

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_688ca65741e0833094b28a27d655a8cd