### PR TITLE
Improve translation reliability

### DIFF
--- a/LiveSubtitles/LiveSubtitles/Translator.swift
+++ b/LiveSubtitles/LiveSubtitles/Translator.swift
@@ -2,9 +2,25 @@ import Foundation
 import NaturalLanguage
 
 class Translator {
+    /// Expected JSON response from LibreTranslate
     private struct TranslateResult: Decodable {
         let translatedText: String
     }
+    /// Possible error returned by LibreTranslate
+    private struct TranslateError: Decodable {
+        let error: String
+    }
+
+    /// Base endpoint for the translation service. Can be overridden at
+    /// runtime using the `LIBRETRANSLATE_URL` environment variable.
+    private let endpoint: URL = {
+        if let value = ProcessInfo.processInfo.environment["LIBRETRANSLATE_URL"],
+           let url = URL(string: value) {
+            return url
+        }
+        return URL(string: "https://translate.argosopentech.com/translate")!
+    }()
+
     private func detectLanguage(of text: String) -> String? {
         let recognizer = NLLanguageRecognizer()
         recognizer.processString(text)
@@ -15,16 +31,27 @@ class Translator {
     /// supplied; otherwise automatic detection will be used.
     func translate(_ text: String, from source: String?, to target: String) async -> String {
         let source = source ?? detectLanguage(of: text) ?? "auto"
-        guard let url = URL(string: "https://libretranslate.de/translate") else { return text }
-        var request = URLRequest(url: url)
+        var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
-        let query = "q=" + (text.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "") + "&source=\(source)&target=\(target)&format=text"
-        request.httpBody = query.data(using: .utf8)
+        let parameters = [
+            "q": text,
+            "source": source,
+            "target": target,
+            "format": "text"
+        ]
+        let body = parameters.map { key, value in
+            "\(key)=\(value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+        }.joined(separator: "&")
+        request.httpBody = body.data(using: .utf8)
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
         do {
             let (data, _) = try await URLSession.shared.data(for: request)
             if let result = try? JSONDecoder().decode(TranslateResult.self, from: data) {
                 return result.translatedText
+            }
+            if let err = try? JSONDecoder().decode(TranslateError.self, from: data) {
+                print("Translation error", err.error)
             }
             if let raw = String(data: data, encoding: .utf8) {
                 print("Unexpected translation response", raw)


### PR DESCRIPTION
## Summary
- make translation endpoint configurable with `LIBRETRANSLATE_URL`
- default to `translate.argosopentech.com`
- better handle translation errors and accept JSON

## Testing
- `swiftc LiveSubtitles/LiveSubtitles/Translator.swift -o /tmp/translator` *(fails: no such module 'NaturalLanguage')*

------
https://chatgpt.com/codex/tasks/task_b_688cb1710308833096794aa722509387