### PR TITLE
Add speech recognition skeleton

### DIFF
--- a/LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift
+++ b/LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift
@@ -1,0 +1,49 @@
+import Foundation
+import AVFoundation
+import Speech
+
+/// Handles live speech recognition using Apple's Speech framework.
+/// This version transcribes Greek audio from the microphone.
+class SpeechRecognizer {
+    private let speechRecognizer: SFSpeechRecognizer? = SFSpeechRecognizer(locale: Locale(identifier: "el-GR"))
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+
+    /// Starts recording audio and delivering transcription results via the handler.
+    func startRecording(resultHandler: @escaping (String) -> Void) throws {
+        guard let recognizer = speechRecognizer, recognizer.isAvailable else {
+            throw NSError(domain: "SpeechRecognizer", code: 1, userInfo: [NSLocalizedDescriptionKey: "Speech recognizer unavailable"]) 
+        }
+
+        request = SFSpeechAudioBufferRecognitionRequest()
+        guard let request = request else { return }
+        request.shouldReportPartialResults = true
+
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
+            request.append(buffer)
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+
+        recognitionTask = recognizer.recognitionTask(with: request) { result, error in
+            if let result = result {
+                resultHandler(result.bestTranscription.formattedString)
+            }
+            if error != nil {
+                self.stopRecording()
+            }
+        }
+    }
+
+    /// Stops recording and ends the current recognition task.
+    func stopRecording() {
+        audioEngine.stop()
+        request?.endAudio()
+        recognitionTask?.cancel()
+        recognitionTask = nil
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# LiveSubtitles
+
+This repository contains the beginnings of an iOS application that captures Greek speech and eventually translates it into English.
+
+## Speech Recognition
+
+The initial approach relies on Apple's `Speech` framework. The `SpeechRecognizer` class under `LiveSubtitles/SpeechRecognizer.swift` demonstrates how to start recording microphone audio and obtain live Greek transcriptions.
+
+For improved accuracy and offline capabilities, the project can later integrate OpenAI's [Whisper](https://github.com/openai/whisper) model. A popular approach is to compile `whisper.cpp` for iOS and bridge it to Swift. This repository currently focuses on the simpler `Speech` framework setup while leaving room to swap in Whisper in the future.
+
+## Usage
+
+1. Open `LiveSubtitles.xcodeproj` in Xcode.
+2. Add `SpeechRecognizer.swift` to your target.
+3. Request microphone and speech recognition permissions in your app's Info.plist.
+4. Use the `SpeechRecognizer` class to start and stop recognition.
+
+The recognized Greek text can later be fed into a machine translation component.


### PR DESCRIPTION
## Summary
- create a README describing planned usage
- add `SpeechRecognizer.swift` with Greek speech transcription using Apple's Speech framework

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688cbd58c8088330af1d70da2ecdd2de