### PR TITLE
Add speech recognition skeleton

### DIFF
--- a/LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift
+++ b/LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift
@@ -1,0 +1,91 @@
+import Foundation
+import AVFoundation
+import Speech
+
+enum SpeechRecognizerError: Error {
+    case speechPermissionDenied
+    case microphonePermissionDenied
+    case recognizerUnavailable
+}
+
+/// Handles live speech recognition using Apple's Speech framework.
+/// This version transcribes Greek audio from the microphone.
+@MainActor
+class SpeechRecognizer {
+    private let speechRecognizer: SFSpeechRecognizer? =
+        SFSpeechRecognizer(locale: Locale(identifier: "el-GR"))
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+
+    /// Requests speech and microphone permissions.
+    func requestAuthorization() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                switch status {
+                case .authorized:
+                    continuation.resume()
+                default:
+                    continuation.resume(throwing: SpeechRecognizerError.speechPermissionDenied)
+                }
+            }
+        }
+
+        try await withCheckedThrowingContinuation { continuation in
+            AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                if granted {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: SpeechRecognizerError.microphonePermissionDenied)
+                }
+            }
+        }
+    }
+
+    private func configureSession() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+
+    /// Starts recording audio and delivering transcription results via the handler.
+    func startRecording(resultHandler: @escaping (String) -> Void) throws {
+        guard let recognizer = speechRecognizer, recognizer.isAvailable else {
+            throw SpeechRecognizerError.recognizerUnavailable
+        }
+
+        try configureSession()
+
+        request = SFSpeechAudioBufferRecognitionRequest()
+        guard let request = request else { return }
+        request.shouldReportPartialResults = true
+
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
+            request.append(buffer)
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+
+        recognitionTask = recognizer.recognitionTask(with: request) { result, error in
+            if let result = result {
+                resultHandler(result.bestTranscription.formattedString)
+            }
+            if error != nil {
+                self.stopRecording()
+            }
+        }
+    }
+
+    /// Stops recording and ends the current recognition task.
+    func stopRecording() {
+        audioEngine.stop()
+        request?.endAudio()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        try? AVAudioSession.sharedInstance().setActive(false)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# LiveSubtitles
+
+This repository contains the beginnings of an iOS application that captures Greek speech and eventually translates it into English.
+
+## Speech Recognition
+
+The initial approach relies on Apple's `Speech` framework. The `SpeechRecognizer` class under `LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift` demonstrates how to start recording microphone audio and obtain live Greek transcriptions. It configures the audio session, requests permissions, and exposes `startRecording`/`stopRecording` methods.
+
+For improved accuracy and offline capabilities, the project can later integrate OpenAI's [Whisper](https://github.com/openai/whisper) model. A popular approach is to compile `whisper.cpp` for iOS and bridge it to Swift. This repository currently focuses on the simpler `Speech` framework setup while leaving room to swap in Whisper in the future.
+
+## Usage
+
+1. Open the Xcode project (e.g. `LiveSubtitles.xcodeproj`).
+2. Drag `SpeechRecognizer.swift` into your app target.
+3. Add `Privacy - Speech Recognition Usage Description` and `Privacy - Microphone Usage Description` to `Info.plist`.
+4. Call `requestAuthorization()` once and use `startRecording` and `stopRecording` as needed.
+
+The recognized Greek text can later be fed into a machine translation component.


### PR DESCRIPTION
## Summary
- rebuild minimal project README with updated instructions
- extend `SpeechRecognizer` with permission requests
- add audio session setup and cleanup helpers

## Testing
- `swift --version`
- `swiftc LiveSubtitles/LiveSubtitles/SpeechRecognizer.swift -emit-library -o /tmp/test.dylib` *(fails: no such module 'AVFoundation')*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688cbd58c8088330af1d70da2ecdd2de